### PR TITLE
Üleliigne koma

### DIFF
--- a/content.md
+++ b/content.md
@@ -5,7 +5,7 @@
 
 ![skeem](images/java.svg)
 
-Tere,
+Tere
 
 Kui soovid programmeerijaks õppida, oled õiges kohas. Käesolevad materjalid on loodud IT Kolledži tarbeks, aga siht on võimaldada igaühel programmeerimist õppida *põhjalikult*. Materjalid pole veel valmis, aga võid juba proovida kuidas hammas peale hakkab (tagasiside kirjuta foorumisse).
 


### PR DESCRIPTION
Üks üleliigne koma kohe teksti alguses. Siin on ju nagu kiri tudengitele.

http://keeleabi.eki.ee/pdf/147.pdf    KIRJA ALGUSESSE pöördumise ja esimese lause vahele ei käi
koma. Sinna sobib hüüumärk, ent kui kirja koostaja ei soovi seda kasutada, võib lõpumärgist loobuda (st vormistada pöördumine
pealkirjana).

Samast siin: http://www.sekretar.ee/blogid/2016/03/21/keelenou-kuidas-e-kirja-korrektselt-alustada-ja-lopetada